### PR TITLE
fix: Blinking with past visited post information

### DIFF
--- a/FE/src/pages/CarPostPage.tsx
+++ b/FE/src/pages/CarPostPage.tsx
@@ -8,7 +8,7 @@ import { RiseLoader } from "react-spinners";
 export default function CarPostPage() {
   const { id } = useParams();
   const { isPending, data } = useQuery({
-    queryKey: ["load_car_post_by_id"],
+    queryKey: [`load_car_post_by_id/${id}`],
     queryFn: async () => {
       const res = await fetch(`/api/list_car_post/${id}`);
       if (res.ok) {


### PR DESCRIPTION
Due to the querykey of the car_post fetch being always the same key it loaded for a second the old information, now the querykey is dynamic with the id of the post